### PR TITLE
update deprecated container status check

### DIFF
--- a/commands
+++ b/commands
@@ -41,7 +41,7 @@ tor_info_cmd() {
     CID=$(< "$DOKKU_TOR_ROOT/CONTAINER")
     dokku_log_info2_quiet "tor status"
 
-    if (is_container_running "$CID"); then
+    if (is_container_status "$CID" "Running"); then
       dokku_log_verbose "running"
     else
       dokku_log_verbose "not running"
@@ -82,7 +82,7 @@ tor_start_cmd() {
   else
     local CID
     CID=$(< "$DOKKU_TOR_ROOT/CONTAINER")
-    if (! is_container_running "$CID"); then
+    if (! is_container_status "$CID" "Running"); then
       docker rm -f "${DOKKU_TOR_CONTAINER_NAME}" &>/dev/null || true
       do_run
     fi


### PR DESCRIPTION
fixes https://github.com/michaelshobbs/dokku-tor/issues/2#issuecomment-1542588275

`is_container_running` was removed in `0.30.0`
https://github.com/dokku/dokku/blob/ac0ba064ce5ff32d53120830d42d97d3472001de/docs/appendices/0.30.0-migration-guide.md?plain=1#L29